### PR TITLE
Skip always_iterable test for PyPy3, fixes #7

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,12 @@
+import sys
+
+
+def pytest_collection_modifyitems(session, config, items):
+    remove_broken_tests(items)
+
+
+def remove_broken_tests(items):
+    # Remove broken tests for PyPy3
+    if hasattr(sys, 'pypy_version_info'):
+        broken_test_names = ['jaraco.itertools.always_iterable']
+        items[:] = (item for item in items if item.name not in broken_test_names)


### PR DESCRIPTION
Hi Jason,
I've made a PR as you suggested. I slightly changed the way the function returns to make it more self-explanatory. If you don't like it, I can change it back to
```py
if six.PY3 and not hasattr(sys, 'pypy_version_info'):
    return
```
but it seemed less clear to me.