### PR TITLE
Fix missing import in ensure_unique() doctest

### DIFF
--- a/jaraco/itertools.py
+++ b/jaraco/itertools.py
@@ -1167,6 +1167,7 @@ def ensure_unique(iterable, key=lambda x: x):
     """
     Wrap an iterable to raise a ValueError if non-unique values are encountered.
 
+    >>> from more_itertools import consume
     >>> list(ensure_unique('abc'))
     ['a', 'b', 'c']
     >>> consume(ensure_unique('abca'))


### PR DESCRIPTION
Add missing import in order to make the test pass.  Otherwise, it fails
with:

```pytb
___________________ [doctest] jaraco.itertools.ensure_unique ___________________
1167
1168     Wrap an iterable to raise a ValueError if non-unique values are encountered.
1169
1170     >>> list(ensure_unique('abc'))
1171     ['a', 'b', 'c']
1172     >>> consume(ensure_unique('abca'))
Differences (unified diff with -expected +actual):
    @@ -1,3 +1,6 @@
     Traceback (most recent call last):
    -...
    -ValueError: Duplicate element 'a' encountered.
    +  File "/usr/lib/pypy3.9/doctest.py", line 1336, in __run
    +    exec(compile(example.source, filename, "single",
    +  File "<doctest jaraco.itertools.ensure_unique[1]>", line 1, in <module>
    +    consume(ensure_unique('abca'))
    +NameError: name 'consume' is not defined
```